### PR TITLE
Release 0.3.0

### DIFF
--- a/icons/circle-tick.svg
+++ b/icons/circle-tick.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m14.25 8.75c-.5 2.5-2.3849 4.85363-5.03069 5.37991-2.64578.5263-5.33066-.7044-6.65903-3.0523-1.32837-2.34784-1.00043-5.28307.81336-7.27989 1.81379-1.99683 4.87636-2.54771 7.37636-1.54771"/>
+<polyline points="5.75 7.75,8.25 10.25,14.25 3.75"/>
+</svg>

--- a/icons/layout-columns.svg
+++ b/icons/layout-columns.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<rect height="10.5" width="12.5" y="2.75" x="1.75"/>
+<line x1="8" y1="3.25" x2="8" y2="12.75"/>
+</svg>

--- a/icons/layout-dashboard.svg
+++ b/icons/layout-dashboard.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<rect height="10.5" width="12.5" y="2.75" x="1.75"/>
+<path d="m8.25 6.75h5.5m-11.5 2.5h5.5m.25-6v9.5"/>
+</svg>

--- a/icons/link-external.svg
+++ b/icons/link-external.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<polyline points="8.25 2.75,2.75 2.75,2.75 13.25,13.25 13.25,13.25 7.75"/>
+<path d="m13.25 2.75-5.5 5.5m3-6.5h3.5v3.5"/>
+</svg>

--- a/icons/signpost.svg
+++ b/icons/signpost.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<polygon points="1.75 9.25,12.25 9.25,14.25 7.00,12.25 4.75,1.75 4.75"/>
+<path d="m7.25 9.75v4.5m0-12.5v2.5"/>
+</svg>

--- a/icons/square-tick.svg
+++ b/icons/square-tick.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<polyline points="10.25 2.75,2.75 2.75,2.75 13.25,13.25 13.25,13.25 9.75"/>
+<polyline points="5.75 7.75,8.25 10.25,14.25 3.75"/>
+</svg>

--- a/icons/stack.svg
+++ b/icons/stack.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m1.75 11 6.25 3.25 6.25-3.25m-12.5-3 6.25 3.25 6.25-3.25m-6.25-6.25-6.25 3.25 6.25 3.25 6.25-3.25z"/>
+</svg>

--- a/icons/wifi-fair.svg
+++ b/icons/wifi-fair.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m1.75 4.75 6.25 8.5 6.25-8.5c-3.25-2.75-9.25-2.75-12.5 0z"/>
+<path d="m4.25 8c2-1.75 5.5-1.75 7.5 0"/>
+</svg>

--- a/icons/wifi-poor.svg
+++ b/icons/wifi-poor.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m1.75 4.75 6.25 8.5 6.25-8.5c-3.25-2.75-9.25-2.75-12.5 0z"/>
+<path d="m5 9c.75-1.75 5.25-1.75 6 0"/>
+</svg>

--- a/icons/wifi-slash.svg
+++ b/icons/wifi-slash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m5.25 3.25c-1.5 0-3.5 1.5-3.5 1.5l6.25 8.5 2.25-3m-1.5-7.5s2.97688-.134944 5.5 2l-2 2.5"/>
+<line x1="4.25" y1="1.75" x2="12.25" y2="12.25"/>
+</svg>

--- a/icons/wifi-warning.svg
+++ b/icons/wifi-warning.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m14.25 4.75c-3.25-2.75-9.25-2.75-12.5 0l6.25 8.5 1-1.5"/>
+<path d="m12.25 13.75v0m0-6v3.5"/>
+</svg>

--- a/icons/wifi.svg
+++ b/icons/wifi.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m1.75 4.75 6.25 8.5 6.25-8.5c-3.25-2.75-9.25-2.75-12.5 0z"/>
+</svg>

--- a/keywords.json
+++ b/keywords.json
@@ -265,6 +265,8 @@
   "laptop": [
     "device"
   ],
+  "layout-columns": [],
+  "layout-dashboard": [],
   "layout-grid": [],
   "layout-list": [],
   "layout-sidebar": [],
@@ -483,5 +485,27 @@
   ],
   "upload": [
     "arrow"
+  ],
+  "wifi": [
+    "connection",
+    "internet"
+  ],
+  "wifi-fair": [
+    "connection",
+    "internet"
+  ],
+  "wifi-poor": [
+    "connection",
+    "internet"
+  ],
+  "wifi-slash": [
+    "connection",
+    "internet",
+    "off"
+  ],
+  "wifi-warning": [
+    "connection",
+    "error",
+    "internet"
   ]
 }

--- a/keywords.json
+++ b/keywords.json
@@ -270,6 +270,10 @@
   "link": [
     "chain"
   ],
+  "link-external": [
+    "arrow",
+    "url"
+  ],
   "mail": [
     "email"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -432,6 +432,10 @@
     "done",
     "success"
   ],
+  "stack": [
+    "layers",
+    "pages"
+  ],
   "star": [
     "night"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -97,6 +97,13 @@
   "circle": [
     "shape"
   ],
+  "circle-tick": [
+    "approve",
+    "check",
+    "correct",
+    "done",
+    "success"
+  ],
   "clipboard": [
     "copy",
     "paste"
@@ -413,6 +420,13 @@
   ],
   "square": [
     "shape"
+  ],
+  "square-tick": [
+    "approve",
+    "check",
+    "correct",
+    "done",
+    "success"
   ],
   "star": [
     "night"

--- a/keywords.json
+++ b/keywords.json
@@ -406,6 +406,10 @@
     "arrow",
     "log-in"
   ],
+  "signpost": [
+    "directions",
+    "milestone"
+  ],
   "sound-down": [
     "audio",
     "sound"


### PR DESCRIPTION
This release adds 12 new icons:

* `link-external` (5e6724eae03a79c3784784fe958e5aca42f4cc1b)
* `circle-tick`, `square-tick` (c234b1c405ea4e3c54ccabbbc7fb1906639a6cb6)
* `signpost` (a1a498e4611857473bd64f90512a731dc490461b)
* `stack` (66b258077fe9e6282e968333cc6528ed6701249d)
* `wifi-fair`, `wifi-poor`, `wifi-slash`, `wifi-warning`, `wifi` (1a1cfce3bb43dace771c78d5904d1cd49fcb9054)
* `layout-columns`, `layout-dashboard` (aaa053f11f4b473dd680c46f63f36b1444400828)