### PR TITLE
Release 0.4.0

### DIFF
--- a/icons/camera-video-slash.svg
+++ b/icons/camera-video-slash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m11.25 10.75 3 1.5v-7.5l-5 2.5v-2.5h-2.5m1.5 7.5h-6.5v-7.5h1.5"/>
+<line x1="1.75" y1="2.25" x2="10.25" y2="14.25"/>
+</svg>

--- a/icons/circle-warning.svg
+++ b/icons/circle-warning.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<circle cx="8" cy="8" r="6.25"/>
+<path d="m8 10.75v0m0-6v3.5"/>
+</svg>

--- a/icons/link-slash.svg
+++ b/icons/link-slash.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m10.75 1.75-5.5 12.5m4.5-9.5c3 0 4.5 1.5 4.5 3.25s-1.5 3.25-4.5 3.25m-3.5-6.5c-3 0-4.5 1.5-4.5 3.25s1.5 3.25 4.5 3.25"/>
+</svg>

--- a/icons/octagon-warning.svg
+++ b/icons/octagon-warning.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<polygon points="5.25 1.75,10.75 1.75,14.25 5.25,14.25 10.75,10.75 14.25,5.25 14.25,1.75 10.75,1.75 5.25"/>
+<path d="m8 11.25v0m0-6.5v3.5"/>
+</svg>

--- a/icons/octagon.svg
+++ b/icons/octagon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<polygon points="5.25 1.75,10.75 1.75,14.25 5.25,14.25 10.75,10.75 14.25,5.25 14.25,1.75 10.75,1.75 5.25"/>
+</svg>

--- a/icons/power.svg
+++ b/icons/power.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m8 1.75v6.5m4.25-5s2 1.29822 2 4.75-2.79822 6.25-6.25 6.25-6.25-2.79822-6.25-6.25 2-4.75 2-4.75"/>
+</svg>

--- a/icons/robot.svg
+++ b/icons/robot.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<rect height="7.5" width="12.5" y="5.75" x="1.75"/>
+<path d="m10.75 8.75v1.5m-5.5-1.5v1.5m-.5-7.5 3.25 3 3.25-3"/>
+</svg>

--- a/icons/rocket.svg
+++ b/icons/rocket.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m4.25 9.75-2-.5s0-1.5.5-3 4-1.5 4-1.5m-.50 7l.5 2s1.5 0 3-.5 1.5-4 1.5-4m-7 .5 2 2s5-2 6.5-4.5 1.5-5.5 1.5-5.5-3 0-5.5 1.5-4.5 6.5-4.5 6.5z"/>
+<path d="m1.75 14.25 2-1-1-1z" fill="currentColor"/>
+<circle cx="10.25" cy="5.75" r=".5" fill="currentColor"/>
+</svg>

--- a/icons/scales.svg
+++ b/icons/scales.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m1.75 3.75c1 1 2.5 1.5 4 0h4.5c1.5 1.5 3 1 4 0m-6.25-2v12m-3.25.5h6.5"/>
+<path d="m12.75 4.75-2 5c.5 1 3.5 1 4 0zm-9.5 0-2 5c.5 1 3.5 1 4 0z"/>
+</svg>

--- a/icons/trophy.svg
+++ b/icons/trophy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<rect height="3.5" width="6.5" y="10.75" x="4.75"/>
+<path d="m8 8.75v2m-3.25-9c-1.5 0-3 .5-3 2.25s1.5 2.25 3 2.25m6.5-4.5c1.5 0 3 .5 3 2.25s-1.5 2.25-3 2.25m-6.5-4.5h6.5v3.5c0 1.5-1 3-3.25 3s-3.25-1.5-3.25-3z"/>
+</svg>

--- a/keywords.json
+++ b/keywords.json
@@ -356,7 +356,7 @@
   "octagon-warning": [
     "attention",
     "caution",
-    "span"
+    "spam"
   ],
   "package": [
     "box"

--- a/keywords.json
+++ b/keywords.json
@@ -388,6 +388,11 @@
   "rotate-clockwise": [
     "arrow"
   ],
+  "scale": [
+    "justice",
+    "law",
+    "license"
+  ],
   "screen-maximise": [],
   "screen-minimise": [],
   "search": [

--- a/keywords.json
+++ b/keywords.json
@@ -521,6 +521,11 @@
   "triangle": [
     "shape"
   ],
+  "trophy": [
+    "award",
+    "cup",
+    "win"
+  ],
   "upload": [
     "arrow"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -104,6 +104,10 @@
     "done",
     "success"
   ],
+  "circle-warning": [
+    "attention",
+    "caution"
+  ],
   "clipboard": [
     "copy",
     "paste"

--- a/keywords.json
+++ b/keywords.json
@@ -345,6 +345,11 @@
   "octagon": [
     "shape"
   ],
+  "octagon-warning": [
+    "attention",
+    "caution",
+    "span"
+  ],
   "package": [
     "box"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -375,6 +375,10 @@
     "new",
     "positive"
   ],
+  "power": [
+    "off",
+    "on"
+  ],
   "printer": [
     "device"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -56,6 +56,10 @@
   "camera-video": [
     "device"
   ],
+  "camera-video-slash": [
+    "device",
+    "off"
+  ],
   "cards": [
     "issues"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -342,6 +342,9 @@
     "success",
     "write"
   ],
+  "octagon": [
+    "shape"
+  ],
   "package": [
     "box"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -283,6 +283,10 @@
     "arrow",
     "url"
   ],
+  "link-slash": [
+    "chain",
+    "unlink"
+  ],
   "mail": [
     "email"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -402,6 +402,13 @@
     "arrow",
     "email"
   ],
+  "robot": [
+    "android",
+    "automate",
+    "bot",
+    "droid",
+    "machine"
+  ],
   "rocket": [
     "blast",
     "launch",

--- a/keywords.json
+++ b/keywords.json
@@ -385,6 +385,12 @@
     "arrow",
     "email"
   ],
+  "rocket": [
+    "blast",
+    "launch",
+    "ship",
+    "space"
+  ],
   "rotate-anti-clockwise": [
     "arrow"
   ],


### PR DESCRIPTION
This release adds 10 new icons:

* `scales` (4b0dbd81bc010a97156d25ea368c946f10d44ca6)
* `octagon` (e8b4251240bf5032f8460e99ebb67b3f4d914a84)
* `rocket` (e4942e861cb1e21b6dbbf94cc215f39f875ca1ce)
* `power` (cc18bc02b84f53a90e85eae8d1b79fd83657d46a)
* `octagon-warning` (70dafb9115f94cb0cfc477961c06c0e152e60428)
* `link-slash` (f67f7072e96fce35ebb394f87d93e2660e781ad2)
* `circle-warning` (c0dc088d4d2434218add05dff8ccb05ebefe4cda)
* `robot` (864bafd19209d344fe7f2d9a2b537aef921796c7)
* `trophy` (2739500432f03a5876f9edd65bed65eefee6e225)
* `camera-video-slash` (8fd9e4209bd5beba8ea3b190f65d396310f4b4bc)