### PR TITLE
Prepare v0.7.0 release

### DIFF
--- a/icons/chip.svg
+++ b/icons/chip.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<rect height="10.5" width="10.5" y="2.75" x="2.75"/>
+<rect height="3.5" width="3.5" y="6.25" x="6.25"/>
+<path d="m2.25 10.25h-1m1-4.5h-1m13.5 4.5h-1m1-4.5h-1m-3.5 8v1m-4.5-1v1m4.5-13.5v1m-4.5-1v1"/>
+</svg>

--- a/icons/gamepad.svg
+++ b/icons/gamepad.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m3.25 3.75c-2 5-2 9 0 9.5s2.5-2 2.5-2h4.5s.5 2.5 2.5 2 2-4.5 0-9.5h-2l-1 1h-3.5l-1-1z"/>
+</svg>

--- a/icons/id.svg
+++ b/icons/id.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<rect height="10.5" width="12.5" y="2.75" x="1.75"/>
+<circle cy="7.5" cx="8" r="2.25"/>
+<path d="m4.75 12.75c0-1 .75-3 3.25-3s3.25 2 3.25 3"/>
+</svg>

--- a/icons/layout-rows.svg
+++ b/icons/layout-rows.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<rect height="10.5" width="12.5" y="2.75" x="1.75"/>
+<line x1="2" y1="8" x2="14" y2="8"/>
+</svg>

--- a/icons/layout-stack-h.svg
+++ b/icons/layout-stack-h.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<rect height="10.5" width="12.5" y="2.75" x="1.75"/>
+<line x1="2" y1="8" x2="14" y2="8"/>
+<line x1="8" y1="8" x2="8" y2="12.75"/>
+</svg>

--- a/icons/layout-stack-v.svg
+++ b/icons/layout-stack-v.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<rect height="10.5" width="12.5" y="2.75" x="1.75"/>
+<line x1="8" y1="3.25" x2="8" y2="12.75"/>
+<line x1="8" y1="8" x2="14" y2="8"/>
+</svg>

--- a/icons/nut.svg
+++ b/icons/nut.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<polygon points="8 1.25 14.25 4.75 14.25 11.25 8 14.75 1.75 11.25 1.75 4.75"/>
+<circle cx="8" cy="8" r="2.25"/>
+</svg>

--- a/icons/plant-pot.svg
+++ b/icons/plant-pot.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m8.75 6.75c0 1.25-.75 3-.75 3m.25-2.5s.75-2-1-3.5-4.5-1-4.5-1 0 2 1.5 3.5 4 1 4 1zm.5-1s-.75-2 1-3.5 4.5-1 4.5-1 0 2-1.5 3.5-4 1-4 1z"/>
+<path d="m4.75 9.75h6.5s.5 4.5-3.25 4.5-3.25-4.5-3.25-4.5z"/>
+</svg>

--- a/icons/sword.svg
+++ b/icons/sword.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m2.75 9.25 1.5 2.5 2 1.5m-4.5 0 1 1m1.5-2.5-1.5 1.5m3-1 8.5-8.5v-2h-2l-8.5 8.5"/>
+</svg>

--- a/icons/swords.svg
+++ b/icons/swords.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m2.75 9.25 1.5 2.5 2 1.5m-4.5 0 1 1m1.5-2.5-1.5 1.5m3-1 8.5-8.5v-2h-2l-8.5 8.5"/>
+<path d="m10.25 12.25-2.25-2.25m2-2 2.25 2.25m1-1-1.5 2.5-2 1.5m4.5 0-1 1m-1.5-2.5 1.5 1.5m-7.25-5.25-4.25-4.25v-2h2l4.25 4.25"/>
+</svg>

--- a/keywords.json
+++ b/keywords.json
@@ -113,6 +113,13 @@
   "chevrons-up": [
     "arrow"
   ],
+  "chip": [
+    "circuit",
+    "computer",
+    "cpu",
+    "processor",
+    "semiconductor"
+  ],
   "circle": [
     "media",
     "shape",

--- a/keywords.json
+++ b/keywords.json
@@ -619,6 +619,20 @@
     "arrow",
     "switch"
   ],
+  "sword": [
+    "attack",
+    "battle",
+    "dagger",
+    "strike",
+    "weapon"
+  ],
+  "swords": [
+    "attack",
+    "battle",
+    "dagger",
+    "strike",
+    "weapon"
+  ],
   "tablet": [
     "device"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -244,6 +244,13 @@
     "email",
     "share"
   ],
+  "gamepad": [
+    "controller",
+    "joypad",
+    "joystick",
+    "play",
+    "videogame"
+  ],
   "gem": [
     "jewel",
     "ruby"

--- a/keywords.json
+++ b/keywords.json
@@ -312,6 +312,7 @@
   "layout-dashboard": [],
   "layout-grid": [],
   "layout-list": [],
+  "layout-rows": [],
   "layout-sidebar": [],
   "lightbulb": [
     "idea"

--- a/keywords.json
+++ b/keywords.json
@@ -424,6 +424,10 @@
     "success",
     "write"
   ],
+  "nut": [
+    "hardware",
+    "settings"
+  ],
   "octagon": [
     "shape"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -494,6 +494,12 @@
     "telephone"
   ],
   "pin": [],
+  "plant-pot": [
+    "eco",
+    "growth",
+    "leaf",
+    "nature"
+  ],
   "plus": [
     "add",
     "new",

--- a/keywords.json
+++ b/keywords.json
@@ -299,6 +299,14 @@
   "home": [
     "house"
   ],
+  "id": [
+    "identification",
+    "identity",
+    "passport",
+    "person",
+    "photo",
+    "picture"
+  ],
   "image": [
     "media",
     "photo"

--- a/keywords.json
+++ b/keywords.json
@@ -314,6 +314,14 @@
   "layout-list": [],
   "layout-rows": [],
   "layout-sidebar": [],
+  "layout-stack-h": [
+    "horizontal",
+    "wide"
+  ],
+  "layout-stack-v": [
+    "tall",
+    "vertical"
+  ],
   "lightbulb": [
     "idea"
   ],


### PR DESCRIPTION
This update adds 10 icons:

* `nut` (825a3438c3f8336ab236ef1aad09ba057bf297df)
* `sword`, `swords` (f0e06843b352beb7157c66dc2ebe2469a0f0edbf)
* `plant-pot` (18d094e2cd46086b27e6cfd5f40897a312512806)
* `layout-rows` (2510ceaab366df097e082fe70afbf505eaf204de)
* `layout-stack-v`, `layout-stack-h` (cbb2f2f4cf7eeacb916d27b5b5424c5afef35281)
* `gamepad` (d95ebeaf1731a0d268602a9f5d092cff16c0ab41)
* `id` (d0a041a15a2f738a22176d93d420898552c7bfae)
* `chip` (761a7d82a8b3fb9ced2c173d022757d102bb3f81)