### PR TITLE
Ready v0.9.0 release

### DIFF
--- a/icons/bell-slash.svg
+++ b/icons/bell-slash.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m5.75 12.25c0 3 4.5 3 4.5 0"/>
+<path d="m12.25 8.25v-3c0-2-1.16605-3.5-4.25-3.5m-3.75 2c-.530590.584957-.5.674089-.5 1.5v3l-2 3.5h8.5"/>
+<path d="m5.75 12.25c0 3 4.5 3 4.5 0"/>
+<path d="m2.75 1.75 10.5 12.5"/>
+</svg>

--- a/icons/bluetooth-connected.svg
+++ b/icons/bluetooth-connected.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m3.75 11.25 8.5-6.25-4.5-3.25v12.5l4.5-3.25-8.5-6.25"/>
+<path d="m1.75 8h1.5m9.5 0h1.5"/>
+</svg>

--- a/icons/bluetooth-searching.svg
+++ b/icons/bluetooth-searching.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m1.75 11.25 8.5-6.25-4.5-3.25v12.5l4.5-3.25-8.5-6.25"/>
+<path d="m13.25 6.25s1 .5 1 1.75-1 1.75-1 1.75m-2-1.75v0"/>
+</svg>

--- a/icons/bluetooth-slash.svg
+++ b/icons/bluetooth-slash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m10.75 6.25 1.5-1.25-4.5-3.25v2.5m4.5 6.75-4.5 3.25v-6l-4 3"/>
+<path d="m1.75 3.25 12.5 9"/>
+</svg>

--- a/icons/clock-alarm.svg
+++ b/icons/clock-alarm.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m11.75 1.75 2.5 2m-10-2-2.5 2m10.5 9.5 1 1m-9.5-1-1 1m5.5-7.5v2.5l-1.5 1"/>
+<circle cx="8" cy="9" r="5.25"/>
+</svg>

--- a/icons/coffee.svg
+++ b/icons/coffee.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m10.75 11.25c4.5 0 4.5-5.5 0-5.5h-9v5c0 5 8.5 5 8.5 0v-5"/>
+<path d="m8.75 1.75v1.5m-3-1.5v1.5m-3-1.5v1.5"/>
+</svg>

--- a/icons/crosshair.svg
+++ b/icons/crosshair.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m8 5.25v-3m0 11.5v-3m2.75-2.75h3m-11.5 0h3"/>
+<circle cx="8" cy="8" r="6.25"/>
+</svg>

--- a/icons/git-cherry-pick.svg
+++ b/icons/git-cherry-pick.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<circle cy="8" cx="5" r="2.25"/>
+<path d="m5 10.75v3.5m0-12.5v3.5"/>
+<path d="m11.75 8h1.5m-4.5-3.25h1.5l1 3.25-1 3.25h-1.5"/>
+</svg>

--- a/icons/git-request-closed.svg
+++ b/icons/git-request-closed.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<circle cy="12.5" cx="12.5" r="1.75"/>
+<circle cy="12.5" cx="3.5" r="1.75"/>
+<circle cy="3.5" cx="3.5" r="1.75"/>
+<path d="m12.25 7.25v3m-8.5-4.5v4.5"/>
+<path d="m14.25 1.75-3.5 3.5m0-3.5 3.5 3.5"/>
+</svg>

--- a/icons/key.svg
+++ b/icons/key.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+<path d="m10 1.75c-2.34721 0-4.25 1.90279-4.25 4.25.00023.37267.04949.74369.14648 1.10352l-4.14648 4.14648v3h3v-1.5h1.5v-1.5h1.5l1.15039-1.15039c.35839.0980.72808.1486 1.09961.1504 2.3472 0 4.25-1.90279 4.25-4.25s-1.9028-4.25-4.25-4.25z"/>
+<circle cx="10.75" cy="5.25" r="0.5" fill="currentColor"/>
+</svg>

--- a/keywords.json
+++ b/keywords.json
@@ -306,6 +306,11 @@
     "merge-request",
     "pull-request"
   ],
+  "git-request-closed": [
+    "cross",
+    "merge-request",
+    "pull-request"
+  ],
   "github": [],
   "gitlab": [],
   "globe": [

--- a/keywords.json
+++ b/keywords.json
@@ -376,6 +376,12 @@
   "info": [
     "information"
   ],
+  "key": [
+    "lock",
+    "password",
+    "secret",
+    "unlock"
+  ],
   "laptop": [
     "device"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -57,6 +57,19 @@
     "connect",
     "wireless"
   ],
+  "bluetooth-connected": [
+    "connect",
+    "wireless"
+  ],
+  "bluetooth-searching": [
+    "connect",
+    "wireless"
+  ],
+  "bluetooth-slash": [
+    "connect",
+    "off",
+    "wireless"
+  ],
   "book": [
     "information"
   ],

--- a/keywords.json
+++ b/keywords.json
@@ -173,6 +173,11 @@
     "date",
     "time"
   ],
+  "clock-alarm": [
+    "reminder",
+    "snooze",
+    "time"
+  ],
   "cloud": [],
   "clover": [
     "charm",

--- a/keywords.json
+++ b/keywords.json
@@ -187,6 +187,12 @@
     "arrow",
     "xml"
   ],
+  "coffee": [
+    "cafe",
+    "drink",
+    "mug",
+    "tea"
+  ],
   "cog": [
     "gear",
     "settings"

--- a/keywords.json
+++ b/keywords.json
@@ -298,6 +298,7 @@
     "present"
   ],
   "git-branch": [],
+  "git-cherry-pick": [],
   "git-commit": [],
   "git-compare": [],
   "git-fork": [],

--- a/keywords.json
+++ b/keywords.json
@@ -203,6 +203,11 @@
     "remove",
     "x"
   ],
+  "crosshair": [
+    "aim",
+    "locate",
+    "target"
+  ],
   "cube": [
     "block",
     "box"

--- a/keywords.json
+++ b/keywords.json
@@ -38,6 +38,11 @@
   "bell": [
     "notifications"
   ],
+  "bell-slash": [
+    "mute",
+    "notifications",
+    "off"
+  ],
   "bin": [
     "delete",
     "remove",


### PR DESCRIPTION
This release adds 10 new icons:

* `crosshair` (35722e1dc4218a8b8ca71ebe8bd9fafefe8e99e1)
* `git-request-closed` (5f54957080a3f7a2ff2cdfdcfaf2f48602ec190c)
* `git-cherry-pick` (123173b38c415255268f0397dd1c044a1f7be72c)
* `bell-slash` (b4bec69f4702ee0c3f7ce366a4fa9a40355e5173)
* `key` (b36aad805fd02add90f4701b0836e6306fa838b9)
* `bluetooth-connected`, `bluetooth-searching`, `bluetooth-slash` (cd5f954a0f3e550f3ff5c6ed9d1b4ee72cec01e8)
* `clock-alarm` (80d886dd54f520a9fab9ab6dd71c011e1146a2d0)
* `coffee` (84e952e4ed97f5b80e076bf0594bc47be267f9e2)