### PR TITLE
Add return type to placeIcons function

### DIFF
--- a/scripts/build/buildTypesFile.js
+++ b/scripts/build/buildTypesFile.js
@@ -33,7 +33,7 @@ function typeTemplate(filenames) {
         icons?: object, attrs?: object, replaceAttr?: string 
     }
     
-    export declare function placeIcons(options?: PlaceIconsOptions);
+    export declare function placeIcons(options?: PlaceIconsOptions): void;
     
     export declare const icons: Icons;
     


### PR DESCRIPTION
### Changes: 
Added `void` return type to `placeIcons` function

### Why?
TS validator throws an error if `tsconfig.json` has ` "noImplicitAny": true`:
`'placeIcons', which lacks return-type annotation, implicitly has an 'any' return type.ts(7010)`